### PR TITLE
修复长按时多次触发音频的问题

### DIFF
--- a/keyboard/keyboard_funcs.js
+++ b/keyboard/keyboard_funcs.js
@@ -1,6 +1,8 @@
 /* Functions for Keyboard Control */
 /* Author: Shuoxue Li <1620480103@qq.com> */
 
+var keyPressed = new Array(500).fill(false);
+
 function AddAudio() {
     var lenkb = drumconfig.Keyboard.length
         //var audio_content = document.getElementById("audio").innerHTML
@@ -153,6 +155,10 @@ function ResponseKeyDown(e) {
     if(ev.keyCode == 27){PoolActOnEsc()}
     if(ev.keyCode == 46){PoolActOnDelete()}
 
+    if(keyPressed[ev.keyCode])
+        return
+    keyPressed[ev.keyCode] = true
+
     kb = document.getElementById('Keyboard')
     notekb = document.getElementById('NoteKeyboard')
 
@@ -174,6 +180,8 @@ function ResponseKeyUp(e) {
     ev = e || window.event
     kb = document.getElementById('Keyboard')
     notekb = document.getElementById('NoteKeyboard')
+
+    keyPressed[ev.keyCode] = false
 
     if(kb.className == "ActivatedKeyboard"){
         var eventindex = drumconfig.Keyboard.indexOf(ev.keyCode)


### PR DESCRIPTION
长按按键的时候会出现多次键盘事件的触发，不好控制节奏。我加了一个逻辑，在up之后再down才会触发后面的事件。大佬看看咋样，如果不太合适也可以直接关闭～